### PR TITLE
Update git commit message limit to 70 chars

### DIFF
--- a/chroma/-git.ch
+++ b/chroma/-git.ch
@@ -631,8 +631,8 @@ chroma/-git-commit-msg-opt-ARG-action() {
         reply+=("$(( __start+10 )) $__end ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}double-quoted-argument]}")
     fi
 
-    if (( ${#_wrd} > 50 )); then
-        for (( __idx1 = 1, __idx2 = 1; __idx1 <= 50; ++ __idx1, ++ __idx2 )); do
+    if (( ${#_wrd} > 70 )); then
+        for (( __idx1 = 1, __idx2 = 1; __idx1 <= 70; ++ __idx1, ++ __idx2 )); do
             # Use __arg from the fast-highlight-process's scope
             while [[ "${__arg[__idx2]}" != "${_wrd[__idx1]}" ]]; do
                 (( ++ __idx2 ))


### PR DESCRIPTION
### Background

`fast-syntax-highlighting` had a great feature in v1.5 that would start highlighting characters in red once your commit message exceeded a certain length. The length was set to 50 characters. As far as I can tell, this changed somewhere between v1.5 and v1.66, and now the entire message string is given a uniform color.

### Changes

This PR works off v1.5 and merely changes the threshold to 70 characters. This coincides with github's limit for single-line commit messages (e.g., look at this [test PR](https://github.com/tjk213/tk-dotfiles/pull/1)).